### PR TITLE
feat(metabase): add dashboard tabs and dashboard_tab_id support

### DIFF
--- a/nao-metabase-mcp-server/src/tools.ts
+++ b/nao-metabase-mcp-server/src/tools.ts
@@ -462,6 +462,15 @@ export const tools: Record<string, Tool> = {
         id: z.number().describe("Dashboard ID"),
         name: z.string().optional().describe("Dashboard name"),
         description: z.string().optional().describe("Dashboard description"),
+        tabs: z
+          .array(
+            z.object({
+              id: z.number().int().describe("Tab ID (use negative numbers for new tabs)"),
+              name: z.string().describe("Tab name"),
+            }),
+          )
+          .optional()
+          .describe("Dashboard tabs. Use negative IDs to create new tabs. Omit to leave tabs unchanged."),
         dashcards: z
           .array(
             z.object({
@@ -470,7 +479,7 @@ export const tools: Record<string, Tool> = {
                 .int()
                 .min(0)
                 .describe("Column position (must be >= 0)"),
-              id: z.number().int().describe("Dashcard ID"),
+              id: z.number().int().describe("Dashcard ID (use negative numbers for new dashcards)"),
               card_id: z.number().int().describe("Card ID"),
               row: z
                 .number()
@@ -479,17 +488,22 @@ export const tools: Record<string, Tool> = {
                 .describe("Row position (must be >= 0)"),
               size_x: z.number().int().min(1).describe("Width (must be >= 1)"),
               size_y: z.number().int().min(1).describe("Height (must be >= 1)"),
+              dashboard_tab_id: z
+                .number()
+                .int()
+                .nullable()
+                .optional()
+                .describe("Tab ID to assign this card to (required for dashboards with tabs)"),
             }),
           )
           .optional(),
       },
     },
-    handler: async ({ id, name, description, dashcards }: any) => {
-      const response = await axiosInstance.put(`/api/dashboard/${id}`, {
-        name,
-        description,
-        dashcards,
-      });
+    handler: async ({ id, name, description, tabs, dashcards }: any) => {
+      const body: any = { name, description };
+      if (tabs !== undefined) body.tabs = tabs;
+      if (dashcards !== undefined) body.dashcards = dashcards;
+      const response = await axiosInstance.put(`/api/dashboard/${id}`, body);
       return {
         content: [
           {


### PR DESCRIPTION
## 🤓 Why

AI generated (using nao + Claude Opus 4.6)

The `metabase-update-dashboard` tool cannot create or update dashboards that use tabs. When a dashboard has tabs, the Metabase API requires each dashcard to include `dashboard_tab_id` to assign it to a tab. Since that field was missing from the tool schema, it gets stripped before the API call, and the API returns a 400 error — even when just re-submitting existing dashcards unchanged.

## 💪 How

Three changes to `nao-metabase-mcp-server/src/tools.ts`:

1. **`tabs` parameter** on `metabase-update-dashboard` — array of `{id, name}` objects. Use negative IDs to create new tabs. Omit to leave tabs unchanged.
2. **`dashboard_tab_id`** field on dashcard objects — nullable int to assign cards to specific tabs (required for dashboards with tabs).
3. **Handler** — only sends `tabs`/`dashcards` to the API when explicitly provided, avoiding accidentally wiping them with `undefined`.

All changes are backwards-compatible: existing calls without `tabs` or `dashboard_tab_id` continue to work as before.

## 🧪 Tests

- Built the project successfully with `npm run build` (no type errors)
- Tested locally by pointing MCP config to the local build
- Successfully created two tabs on an existing Metabase dashboard and assigned one chart to each tab via the MCP tool
- Verified the dashboard renders correctly with tabs in the Metabase UI